### PR TITLE
Fixed error message output damaging AJAX results on file upload, resolves #25

### DIFF
--- a/system/includes/start.php
+++ b/system/includes/start.php
@@ -7,6 +7,9 @@
  * Licensed under the MIT license, located in LICENSE.txt
  */
 
+// start output buffering (with compression)
+ob_start('ob_gzhandler');
+
 /* Important global vars */
 $q = ""; // which module to use
 $config = array (); // all config from config file and amended with table cc_config
@@ -25,8 +28,7 @@ $ajax = false; // to find out if its an ajax call
 // or we could put the content of churchtools_main direct in this file
 
 /**
- * Shutdown function, if an error happened, an error message is displayed.
- * FIXME: need to be changed - this errors are corrupting json answers
+ * Shutdown function, if an error happened, an error message is return as custom PHP header.
  *
  * global $ajax currently will be set to true in CTAjaxHandler! (there are errors caused by debugging which was hindering)
  * if error on ajax is needed, add something like $json['error'] = $info;
@@ -37,11 +39,10 @@ $ajax = false; // to find out if its an ajax call
  * I think heavy core errors shouldnt be shown on the page and all others should be catched by an exception handler.
  */
 function handleShutdown() {
-  global $ajax;
   $error = error_get_last();
-  if (!$ajax && $error !== NULL) { // no Error notizes on ajax requests!
-    $info = "[ERROR] file:" . $error['file'] . ":" . $error['line'] . " <br/><i>" . $error['message'] . '</i>' . PHP_EOL;
-    echo '<div class="alert alert-error">' . $info . '</div>';
+  if (isset($error) && $error['type'] !== E_DEPRECATED) {
+    $info = $error['file'] . ' (line ' . $error['line'] . '): ' . $error['message'];
+	header('X-CT-Error: ' . $info);
   }
 }
 

--- a/system/includes/start.php
+++ b/system/includes/start.php
@@ -41,8 +41,7 @@ $ajax = false; // to find out if its an ajax call
 function handleShutdown() {
   $error = error_get_last();
   if (isset($error) && $error['type'] !== E_DEPRECATED) {
-    $info = $error['file'] . ' (line ' . $error['line'] . '): ' . $error['message'];
-	header('X-CT-Error: ' . $info);
+    header('X-CT-Error: ' . $error['file'] . ' (line ' . $error['line'] . '): ' . $error['message']);
   }
 }
 


### PR DESCRIPTION
This patch changes the error output. It uses a custom HTTP header "X-CT-Error" instead of outputting the error message with the body, possibly damaging JSON results (as for instance after file uploads).
To avoid errors thrown by the header() function, output buffering has been enabled, so that all data will definitely be flushed after the header() calls.
For performance, output buffering has been registered with the "ob_gzhandler" which does automatic gzip compression of the response body for supporting browsers.