### PR TITLE
Deduplication of file storage

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,5 @@
 php_value memory_limit 64M
+php_value always_populate_raw_post_data -1
 
 <FilesMatch "\.(col|pro5plx|csv)$">
   ForceType application/octet-stream

--- a/system/churchcore/cc_standardview.js
+++ b/system/churchcore/cc_standardview.js
@@ -760,35 +760,29 @@ StandardTableView.prototype.renderTooltipForFiles = function (tooltip, f, editau
   var t=this;
   var rows = new Array();
   var i = f.bezeichnung.lastIndexOf(".");
-  if (i>0)
-
-  switch (f.bezeichnung.substr(i,99).toLowerCase()) {
-    case '.mp3':
-      rows.push('<audio style="width:300px" src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    case '.wav':
-      rows.push('<audio style="width:300px" src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    case '.m4a':
-      rows.push('<video src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    case '.mp4':
-      rows.push('<video src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    case '.avi':
-      rows.push('<video src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    case '.mpeg':
-      rows.push('<video src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    case '.jpg':
-      rows.push('<img style="max-width:200px;max-height:200px" src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    case '.png':
-      rows.push('<img style="max-width:200px;max-height:200px" src="'+masterData.files_url+"/files/"+f.domain_type+"/"+f.domain_id+"/"+f.filename+'"/>');
-      break;
-    default:
-      break;
+  if (i>0) {
+    var getUrl = function (f) {
+      return "?q=churchservice/filedownload&id=" + f.id + "&filename=" + f.filename;
+    };
+    switch (f.bezeichnung.substr(i).toLowerCase()) {
+      case '.mp3':
+      case '.wav':
+        rows.push('<audio style="width:300px" src="' + getUrl(f) + '"/>');
+        break;
+      case '.m4a':
+      case '.mp4':
+      case '.avi':
+      case '.mpeg':
+        rows.push('<video src="' + getUrl(f) + '"/>');
+        break;
+      case '.jpg':
+      case '.jpeg':
+      case '.png':
+        rows.push('<img style="max-width:200px;max-height:200px" src="' + getUrl(f) + '"/>');
+        break;
+      default:
+        break;
+    }
   }
 
   if (f.modified_date!=null)

--- a/system/churchcore/classes/qqFileUploader.class.php
+++ b/system/churchcore/classes/qqFileUploader.class.php
@@ -4,7 +4,7 @@
  * Fileuploader
  */
 class qqFileUploader {
-  private $allowedExtensions = array ();
+  private $allowedExtensions = array();
   private $sizeLimit = 10485760;
   private $file;
 
@@ -12,7 +12,7 @@ class qqFileUploader {
    * create qqUploadedFileXhr or qqUploadedFileForm depending of variable set (get or file)
    *
    * @param array $allowedExtensions
-   * @param number $sizeLimit
+   * @param int $sizeLimit
    */
   function __construct(array $allowedExtensions = array(), $sizeLimit = 10485760) {
     $this->allowedExtensions = array_map("strtolower", $allowedExtensions);
@@ -40,7 +40,6 @@ class qqFileUploader {
     $postSize = $this->toBytes(ini_get('post_max_size'));
     $uploadSize = $this->toBytes(ini_get('upload_max_filesize'));
     if ($postSize < $this->sizeLimit || $uploadSize < $this->sizeLimit) {
-      $size = max(1, $this->sizeLimit / 1024 / 1024) . 'M';
       throw new CTException("Entweder POST_MAX_SIZE und UPLOAD_MAX_SIZE erhöhen oder Zahl erniedrigen.");
     }
   }
@@ -112,8 +111,7 @@ class qqFileUploader {
 
     $pathinfo = pathinfo($this->file->getName());
     $bezeichnung = $pathinfo['filename'];
-    // $filename = "aaaaa";
-    $filename = md5(uniqid());
+    $filename = $this->file->getFileHash();
     $ext = $pathinfo['extension'];
 
     if ($this->allowedExtensions && !in_array(strtolower($ext), $this->allowedExtensions)) {
@@ -126,7 +124,7 @@ class qqFileUploader {
       $id = db_insert('cc_file')->fields(array (
           "domain_type" =>  getVar("domain_type"),
           "domain_id" =>  getVar("domain_id"),
-          "filename" => $filename . '.' . $ext,
+          "filename" => $filename,
           "bezeichnung" => $bezeichnung . '.' . $ext,
           "modified_date" => $dt->format('Y-m-d H:i:s'),
           "modified_pid" => $user->id
@@ -134,7 +132,7 @@ class qqFileUploader {
     }
     else $id = null;
 
-    $filename_absolute = "$uploadDirectory$filename.$ext";
+    $filename_absolute = "$uploadDirectory$filename";
     if ($this->file->save($filename_absolute)) {
 
 // Sample for resizing using different max values for x, y
@@ -173,7 +171,7 @@ class qqFileUploader {
         }
       }
 
-      return array ('success' => true, "id" => $id, "filename" => "$filename.$ext", "bezeichnung" => "$bezeichnung.$ext");
+      return array ('success' => true, "id" => $id, "filename" => "$filename", "bezeichnung" => "$bezeichnung.$ext");
     }
     else return array ('error' => t('could.not.save.file.upload.canceled.or.server.error'));
   }
@@ -184,23 +182,40 @@ class qqFileUploader {
  * Handle file uploads via XMLHttpRequest
  */
 class qqUploadedFileXhr {
+	
+  private $tmpfile = null;
+  private $realSize = null;
+  
+  private function createTempFile() {
+	if(!isset($this->tmpfile)) {
+	  $input = fopen('php://input', 'rb');
+	  $this->tmpfile = tempnam(sys_get_temp_dir(), 'upload');
+	  $temp = fopen($this->tmpfile, 'w');
+	  $this->realSize = stream_copy_to_stream($input, $temp);
+	  fclose($temp);
+      fclose($input);
+	}
+	return $this->tmpfile;
+  }
+  
+  function getFileHash($algo = 'sha256') {
+	return hash_file($algo, $this->createTempFile());
+  }
 
   /**
    * Save the file to the specified path
    * @return boolean TRUE on success
    */
   function save($path) {
-    $input = fopen("php://input", "r");
-    $temp = tmpfile();
-    $realSize = stream_copy_to_stream($input, $temp);
-    fclose($input);
-
-    if ($realSize != $this->getSize()) return false;
-
-    $target = fopen($path, "w");
-    fseek($temp, 0, SEEK_SET);
+    $tmpname = $this->createTempFile();
+    if ($this->realSize != $this->getSize()) {
+      return false;
+    }
+    $temp = fopen($tmpname, 'rb');
+    $target = fopen($path, 'w');
     stream_copy_to_stream($temp, $target);
     fclose($target);
+    fclose($temp);
 
     return true;
   }
@@ -230,6 +245,11 @@ class qqUploadedFileXhr {
     }
   }
 
+  //delete temporary file on object destruction
+  function __destruct() {
+    unlink($this->tmpfile);
+  }
+
 }
 
 /**
@@ -247,6 +267,10 @@ class qqUploadedFileForm {
     }
     return true;
   }
+  
+  function getFileHash($algo = 'sha256') {
+	return hash_file($algo, $_FILES['qqfile']['tmp_name']);
+  }
 
   function getName() {
     return $_FILES['qqfile']['name'];
@@ -257,11 +281,3 @@ class qqUploadedFileForm {
   }
 
 }
-
-
-
-
-
-
-
-

--- a/system/churchcore/classes/qqFileUploader.class.php
+++ b/system/churchcore/classes/qqFileUploader.class.php
@@ -5,7 +5,7 @@
  */
 class qqFileUploader {
   private $allowedExtensions = array();
-  private $sizeLimit = 10485760;
+  private $sizeLimit = 10 * 1024 * 1024;
   private $file;
 
   /**
@@ -14,9 +14,11 @@ class qqFileUploader {
    * @param array $allowedExtensions
    * @param int $sizeLimit
    */
-  function __construct(array $allowedExtensions = array(), $sizeLimit = 10485760) {
+  function __construct(array $allowedExtensions = array(), $sizeLimit = null) {
     $this->allowedExtensions = array_map("strtolower", $allowedExtensions);
-    $this->sizeLimit = $sizeLimit;
+    if(isset($sizeLimit)) {
+      $this->sizeLimit = $sizeLimit;
+    }
 
     $this->checkServerSettings();
 
@@ -182,24 +184,24 @@ class qqFileUploader {
  * Handle file uploads via XMLHttpRequest
  */
 class qqUploadedFileXhr {
-	
+
   private $tmpfile = null;
   private $realSize = null;
-  
+
   private function createTempFile() {
-	if(!isset($this->tmpfile)) {
-	  $input = fopen('php://input', 'rb');
-	  $this->tmpfile = tempnam(sys_get_temp_dir(), 'upload');
-	  $temp = fopen($this->tmpfile, 'w');
-	  $this->realSize = stream_copy_to_stream($input, $temp);
-	  fclose($temp);
+    if(!isset($this->tmpfile)) {
+      $input = fopen('php://input', 'rb');
+      $this->tmpfile = tempnam(sys_get_temp_dir(), 'upload');
+      $temp = fopen($this->tmpfile, 'w');
+      $this->realSize = stream_copy_to_stream($input, $temp);
+      fclose($temp);
       fclose($input);
-	}
-	return $this->tmpfile;
+    }
+    return $this->tmpfile;
   }
-  
+
   function getFileHash($algo = 'sha256') {
-	return hash_file($algo, $this->createTempFile());
+    return hash_file($algo, $this->createTempFile());
   }
 
   /**
@@ -267,9 +269,9 @@ class qqUploadedFileForm {
     }
     return true;
   }
-  
+
   function getFileHash($algo = 'sha256') {
-	return hash_file($algo, $_FILES['qqfile']['tmp_name']);
+    return hash_file($algo, $_FILES['qqfile']['tmp_name']);
   }
 
   function getName() {

--- a/system/churchcore/uploadFile.php
+++ b/system/churchcore/uploadFile.php
@@ -11,18 +11,18 @@ function churchcore__uploadfile() {
   $allowedExtensions = array ();
   // max file size in bytes
 
-  $sizeLimit = ($s = getConf("max_uploadfile_size_kb")) ? ($s * 1024) : (10 * 1024 * 1024);
+  $sizeLimit = ($s = getConf('max_uploadfile_size_kb')) ? ($s * 1024) : (10 * 1024 * 1024);
 
   $result = null;
   try {
     $uploader = new qqFileUploader($allowedExtensions, $sizeLimit);
   }
   catch (Exception $e) {
-    $result = "Entweder POST_MAX_SIZE und UPLOAD_MAX_SIZE erhöhen oder Zahl erniedrigen. ";
+    $result = 'Entweder POST_MAX_SIZE und UPLOAD_MAX_SIZE erhöhen oder Zahl erniedrigen.';
   }
   if ($result == null) {
     $file_dir = $files_dir . "/blobs/";
-    if (!file_exists($file_dir)) mkdir($file_dir, 0755, true);
+    if (!file_exists($file_dir)) mkdir($file_dir, 0777, true);
     $result = $uploader->handleUpload($file_dir);
   }
   // to pass data through iframe you will need to encode all html tags

--- a/system/churchcore/uploadFile.php
+++ b/system/churchcore/uploadFile.php
@@ -18,13 +18,12 @@ function churchcore__uploadfile() {
     $uploader = new qqFileUploader($allowedExtensions, $sizeLimit);
   }
   catch (Exception $e) {
-    $result = "Entweder POST_MAX_SIZE und UPLOAD_MAX_SIZE erhöhen oder Zahl erniedrigen.";
+    $result = "Entweder POST_MAX_SIZE und UPLOAD_MAX_SIZE erhöhen oder Zahl erniedrigen. ";
   }
   if ($result == null) {
-    $file_dir = $files_dir . "/files/" . getVar("domain_type") . "/";
-    if ($id = getVar("domain_id")) $file_dir .= $id;
-    if (!file_exists($file_dir)) mkdir($file_dir, 0777, true);
-    $result = $uploader->handleUpload($file_dir . "/");
+    $file_dir = $files_dir . "/blobs/";
+    if (!file_exists($file_dir)) mkdir($file_dir, 0755, true);
+    $result = $uploader->handleUpload($file_dir);
   }
   // to pass data through iframe you will need to encode all html tags
   echo htmlspecialchars(json_encode($result), ENT_NOQUOTES);

--- a/system/churchservice/cs_listview.js
+++ b/system/churchservice/cs_listview.js
@@ -2731,7 +2731,7 @@ ListView.prototype.attachFile = function(event) {
                       "<p>f&uuml;r <i>"+ev.bezeichnung+"</i> wurde eine neue Datei hochgeladen. Du wirst informiert, da Du zum Dienst angefragt bist.";
                   if ((kommentar!=null) && (kommentar!=""))
                     obj.inhalt=obj.inhalt+'<p><i>'+kommentar+'</i></p>';
-                  obj.inhalt=obj.inhalt+'<ul><li><a href="'+masterData.files_url+"/files/service/"+ev.id+"/"+res.filename+'">'+res.bezeichnung+'</a></ul>';
+                  obj.inhalt=obj.inhalt+'<ul><li><a href="' + masterData.base_url + '?q=churchservice/filedownload&id=' + res.id + '&filename=' + res.filename + '">'+res.bezeichnung+'</a></ul>';
                   obj.domain_id=ev.id;
                   obj.usetemplate="true";
                   obj.func="sendEMailToPersonIds";

--- a/system/churchservice/cs_listview.js
+++ b/system/churchservice/cs_listview.js
@@ -2731,7 +2731,7 @@ ListView.prototype.attachFile = function(event) {
                       "<p>f&uuml;r <i>"+ev.bezeichnung+"</i> wurde eine neue Datei hochgeladen. Du wirst informiert, da Du zum Dienst angefragt bist.";
                   if ((kommentar!=null) && (kommentar!=""))
                     obj.inhalt=obj.inhalt+'<p><i>'+kommentar+'</i></p>';
-                  obj.inhalt=obj.inhalt+'<ul><li><a href="' + masterData.base_url + '?q=churchservice/filedownload&id=' + res.id + '&filename=' + res.filename + '">'+res.bezeichnung+'</a></ul>';
+                  obj.inhalt=obj.inhalt+'<ul><li><a href="'+masterData.base_url+'?q=churchservice/filedownload&id='+res.id+'&filename='+res.filename+'">'+res.bezeichnung+'</a></ul>';
                   obj.domain_id=ev.id;
                   obj.usetemplate="true";
                   obj.func="sendEMailToPersonIds";


### PR DESCRIPTION
This commit implements a deduplication feature, using the PHP Hash extension (should be available in every common PHP binary, especially under PHP 5.3) for file naming and a common (non-accessible) directory for inter-module storage.
This patch has been discussed with Matthias Huber, please contact him for further information! ;)