### PR TITLE
Yet another security fix: create really random filenames…

### DIFF
--- a/system/churchdb/upload.php
+++ b/system/churchdb/upload.php
@@ -144,10 +144,14 @@ class qqFileUploader {
 
         if ($this->file->save($uploadDirectory . $filename . '.' . $ext)){
 
-
-          $person_id = $_GET['userid'];
-          $filename_old=$uploadDirectory . $filename . '.' . $ext;
-          $filename=md5(uniqid()).'.'.$ext;
+          $filename_old = $uploadDirectory . $filename . '.' . $ext;
+            
+          if (function_exists('openssl_random_pseudo_bytes')) {
+              $filename = bin2hex(openssl_random_pseudo_bytes(32)).'.'.$ext;
+          } else {
+              $rands = array_map('mt_rand', array_fill(0, 10, 0), array_fill(0, 10, mt_getrandmax()));
+              $filename = md5(implode($rands)).'.'.$ext;
+          }
 
           if (rename($filename_old, $files_dir."/fotos/".$filename)) {
               // Get new dimensions

--- a/system/includes/db_updates.php
+++ b/system/includes/db_updates.php
@@ -1957,6 +1957,15 @@ function run_db_updates($db_version) {
     set_version("2.57");
 
   case '2.57':
+    //not exactly a database update, but is there any better place for it?
+    $htaccess = __DIR__ . '/../../' . $files_dir . '/.htaccess';
+    if (file_exists($htaccess)) {
+      $handle = fopen($htaccess, 'a');
+      if ($handle) {
+        fwrite($handle, "# IMPORTANT, prevents directory content listing!\nOptions -Indexes\n");
+        fclose($handle);
+      }
+    }
     set_version("2.58");
 
   } //end switch

--- a/system/main/home.php
+++ b/system/main/home.php
@@ -126,6 +126,7 @@ function checkFilesDir() {
     $handle = fopen($files_dir . "/.htaccess", 'w+');
     if ($handle) {
       fwrite($handle, "Deny from all\n");
+      fwrite($handle, "# IMPORTANT, prevents directory content listing!\nOptions -Indexes\n");
       fclose($handle);
     }
   }


### PR DESCRIPTION
… and prevent content sniffing on fotos directory

Huston, we have a (security) problem:
- Hochgeladene Dateien werden auch im frei zugänglichen Verzeichnis "fotos" abgelegt, wenn es keine Bilder sind (PHP-Dateien...)
- Durch Directory Listing, das auf einigen Servern aktiviert ist, kann man sehr einfach den Dateinamen heraus finden und dann sein hochgeladenes Skript ausführen.
- Selbst wenn das Directory Listing ausgeschaltet wurde, ist die Anzahl möglicher Werte von md5(uniqid()) dieselbe wie die von uniqid(): Es gibt pro Sekunde nur 10^6 Möglichkeiten. Da der Server netterweise bei jedem HTTP-Request sagt wie spät es bei ihm gerade ist, kann man das leicht Brute-Force durch probieren.

Lessons Learned:
Wenn man Zufall will: RTFM - bevor es knallt!
Der rote Kasten ist eigentlich kaum zu übersehen: https://secure.php.net/manual/de/function.uniqid.php